### PR TITLE
Allow driver to provide default NanostackRfPhy

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,7 +1,11 @@
 {
     "name": "spirit1",
     "config": {
-	"mac-address": "{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}"
+	   "mac-address": "{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}",
+        "provide-default": {
+            "help": "Provide default NanostackRfpy. [true/false]",
+            "value": false
+        }
     },
     "macros": ["USE_STM32F4XX_NUCLEO", "X_NUCLEO_IDS01A4", "SPIRIT_USE_FULL_ASSERT"]
 }

--- a/source/NanostackRfPhySpirit1.cpp
+++ b/source/NanostackRfPhySpirit1.cpp
@@ -826,5 +826,16 @@ void NanostackRfPhySpirit1::set_mac_address(uint8_t *mac)
     rf_if_unlock();
 }
 
+#if MBED_CONF_SPIRIT1_PROVIDE_DEFAULT
+
+
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+  static NanostackRfPhySpirit1 rf_phy(SPIRIT1_SPI_MOSI, SPIRIT1_SPI_MISO, SPIRIT1_SPI_SCLK, SPIRIT1_DEV_IRQ, SPIRIT1_DEV_CS, SPIRIT1_DEV_SDN, SPIRIT1_BRD_LED);
+  return rf_phy;
+}
+
+#endif // MBED_CONF_SPIRIT1_PROVIDE_DEFAULT
+
 #endif /* MBED_CONF_RTOS_PRESENT */
 #endif /* MBED_CONF_NANOSTACK_CONFIGURATION */


### PR DESCRIPTION
Application can set "spirit.provide-default: true" in the mbed_app.json
to allow Spirit driver to be used by LowpanInterface as a default driver.

Similar to https://github.com/ARMmbed/atmel-rf-driver/pull/65